### PR TITLE
Add OpenRouter API support in a new module

### DIFF
--- a/cofounder/api/utils/openai.js
+++ b/cofounder/api/utils/openai.js
@@ -1,6 +1,7 @@
 import fs from "fs";
 import OpenAI from "openai";
 import dotenv from "dotenv";
+import openrouter from "./openrouter.js"; // Import the new openrouter module
 dotenv.config();
 
 let openai;
@@ -17,6 +18,10 @@ async function inference({
 	messages,
 	stream = process.stdout,
 }) {
+	if (process.env.OPENROUTER_TOKEN) {
+		return openrouter.inference({ model, messages, stream });
+	}
+
 	const streaming = await openai.chat.completions.create({
 		model,
 		messages,
@@ -55,6 +60,7 @@ async function inference({
 		usage: { model, ...usage },
 	};
 }
+
 async function vectorize({
 	texts,
 	model = process.env.EMBEDDING_MODEL || `text-embedding-3-small`,

--- a/cofounder/api/utils/openrouter.js
+++ b/cofounder/api/utils/openrouter.js
@@ -1,0 +1,58 @@
+import fetch from "node-fetch";
+
+async function inference({ model, messages, stream = process.stdout }) {
+	const response = await fetch("https://api.openrouter.ai/v1/chat/completions", {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${process.env.OPENROUTER_TOKEN}`,
+		},
+		body: JSON.stringify({
+			model,
+			messages,
+			stream: true,
+		}),
+	});
+
+	if (!response.ok) {
+		throw new Error(`OpenRouter API request failed: ${response.statusText}`);
+	}
+
+	const reader = response.body.getReader();
+	const decoder = new TextDecoder("utf-8");
+	let text = "";
+	let usage = {};
+	let cutoff_reached = false;
+	let chunks_buffer = "";
+	let chunks_iterator = 0;
+	const chunks_every = 5;
+
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		const chunk = decoder.decode(value, { stream: true });
+		text += chunk;
+		chunks_buffer += chunk;
+		chunks_iterator++;
+		if (stream?.cutoff) {
+			if (!cutoff_reached && text.includes(stream.cutoff)) {
+				cutoff_reached = true;
+			}
+		}
+		if (!(chunks_iterator % chunks_every)) {
+			stream.write(!cutoff_reached ? chunks_buffer : " ...");
+			chunks_buffer = "";
+		}
+	}
+
+	stream.write(`\n`);
+
+	return {
+		text,
+		usage: { model, ...usage },
+	};
+}
+
+export default {
+	inference,
+};


### PR DESCRIPTION
This pull request introduces a new integration with the OpenRouter API to handle inferences when an `OPENROUTER_TOKEN` is available. The main changes include importing the new OpenRouter module and modifying the inference function to use this new module conditionally.

Integration with OpenRouter API:

* [`cofounder/api/utils/openai.js`](diffhunk://#diff-74163c4dc9ec518765848cfadfbe40808be738fb601883335ec95b10d395cda8R4): Imported the new `openrouter` module.
* [`cofounder/api/utils/openai.js`](diffhunk://#diff-74163c4dc9ec518765848cfadfbe40808be738fb601883335ec95b10d395cda8R21-R24): Modified the `inference` function to use `openrouter.inference` when `OPENROUTER_TOKEN` is set.
* [`cofounder/api/utils/openrouter.js`](diffhunk://#diff-c5328e6182a5134deaf28379fba1fc87004e5527e67e89ff66606587427f3444R1-R58): Added a new module to handle inferences using the OpenRouter API, including a function to send requests and process responses.

Additional changes:

* [`cofounder/api/utils/openai.js`](diffhunk://#diff-74163c4dc9ec518765848cfadfbe40808be738fb601883335ec95b10d395cda8R63): Added a blank line for better readability.* **New Module**: Create `openrouter.js` to handle OpenRouter API requests using `OPENROUTER_TOKEN`
  - Implement `inference` function to make API requests to OpenRouter
  - Export the `inference` function for use in other modules